### PR TITLE
Added resizeable window functions

### DIFF
--- a/libui/src/controls/window.rs
+++ b/libui/src/controls/window.rs
@@ -126,8 +126,8 @@ impl Window {
     /// Set whether or not this window is resizeable by the user at runtime.
     /// 
     /// This method is merely a hint and may be ignored by the system.
-    pub fn set_resizeable(&mut self, resizable: bool) {
-        unsafe { libui_ffi::uiWindowSetResizeable(self.uiWindow, resizable as c_int) }
+    pub fn set_resizeable(&mut self, resizeable: bool) {
+        unsafe { libui_ffi::uiWindowSetResizeable(self.uiWindow, resizeable as c_int) }
     }
 
     /// Sets the window's child widget. The window can only have one child widget at a time.

--- a/libui/src/controls/window.rs
+++ b/libui/src/controls/window.rs
@@ -118,6 +118,18 @@ impl Window {
         unsafe { libui_ffi::uiWindowSetMargined(self.uiWindow, margined as c_int) }
     }
 
+    /// Check whether or not this window is resizeable by the user at runtime.
+    pub fn resizeable(&self) -> bool {
+        unsafe { libui_ffi::uiWindowResizeable(self.uiWindow) != 0 }
+    }
+
+    /// Set whether or not this window is resizeable by the user at runtime.
+    /// 
+    /// This method is merely a hint and may be ignored by the system.
+    pub fn set_resizeable(&mut self, resizable: bool) {
+        unsafe { libui_ffi::uiWindowSetResizeable(self.uiWindow, resizable as c_int) }
+    }
+
     /// Sets the window's child widget. The window can only have one child widget at a time.
     pub fn set_child<T: Into<Control>>(&mut self, child: T) {
         unsafe { libui_ffi::uiWindowSetChild(self.uiWindow, child.into().as_ui_control()) }


### PR DESCRIPTION
Added the `resizeable` and `set_resizeable` functions to check and set whether the window is resizeable. Tested to work as intended on MacOS 14.5 and Windows 11 computers.

The original `libui-ng` project opts for the UK spelling "resizeable" as opposed to the US spelling "resizable". I've opted to stick with the former for consistency with the base project, but a spellchecker may mark it as misspelled.