### PR TITLE
Fixed disabled menu items bug on macOS

### DIFF
--- a/libui/src/controls/window.rs
+++ b/libui/src/controls/window.rs
@@ -138,6 +138,7 @@ impl Window {
     /// Allow the user to select an existing file using the systems file dialog
     pub fn open_file(&self) -> Option<PathBuf> {
         let ptr = unsafe { libui_ffi::uiOpenFile(self.uiWindow) };
+        self.clone().show();
         if ptr.is_null() {
             return None;
         };
@@ -151,6 +152,7 @@ impl Window {
     /// Allow the user to select a new or existing file using the systems file dialog.
     pub fn save_file(&self) -> Option<PathBuf> {
         let ptr = unsafe { libui_ffi::uiSaveFile(self.uiWindow) };
+        self.clone().show();
         if ptr.is_null() {
             return None;
         };
@@ -164,6 +166,7 @@ impl Window {
     /// Allow the user to select a single folder using the systems folder dialog.
     pub fn open_folder(&self) -> Option<PathBuf> {
         let ptr = unsafe { libui_ffi::uiOpenFolder(self.uiWindow) };
+        self.clone().show();
         if ptr.is_null() {
             return None;
         };

--- a/libui/src/controls/window.rs
+++ b/libui/src/controls/window.rs
@@ -180,8 +180,9 @@ impl Window {
         unsafe {
             let c_title = CString::new(title.as_bytes().to_vec()).unwrap();
             let c_description = CString::new(description.as_bytes().to_vec()).unwrap();
-            libui_ffi::uiMsgBox(self.uiWindow, c_title.as_ptr(), c_description.as_ptr())
+            libui_ffi::uiMsgBox(self.uiWindow, c_title.as_ptr(), c_description.as_ptr());
         }
+        self.clone().show();
     }
 
     /// Open an error-themed message box to show a message to the user.
@@ -190,8 +191,9 @@ impl Window {
         unsafe {
             let c_title = CString::new(title.as_bytes().to_vec()).unwrap();
             let c_description = CString::new(description.as_bytes().to_vec()).unwrap();
-            libui_ffi::uiMsgBoxError(self.uiWindow, c_title.as_ptr(), c_description.as_ptr())
+            libui_ffi::uiMsgBoxError(self.uiWindow, c_title.as_ptr(), c_description.as_ptr());
         }
+        self.clone().show();
     }
 
     pub unsafe fn destroy_all_windows() {


### PR DESCRIPTION
Fixes an issue where menu items were getting disabled by successive message box popups generated by the `modal_msg` and `modal_err` methods. See #8 for a more in-depth explanation.