### PR TITLE
Fix `builder.rs` example

### DIFF
--- a/libui/examples/builder.rs
+++ b/libui/examples/builder.rs
@@ -25,7 +25,7 @@ fn main() {
                     Stretchy: let input_group = Group("Entries") {
                         let form = Form(padded: true) {
                             (Compact, "Entry"): let entry = Entry()
-                            (Compact, "Password Entry"): let entry_pwd = Entry()
+                            (Compact, "Password Entry"): let entry_pwd = PasswordEntry()
                             (Compact, "Search Entry"): let entry_search = SearchEntry()
                             (Stretchy, "Multiline Entry"): let entry_multi = MultilineEntry()
                             (Stretchy, "Non-wrapping Entry"): let entry_nowrap = MultilineEntry( wrapping: false )


### PR DESCRIPTION
I noticed that the `builder.rs` example is using the wrong entry type for the password example.